### PR TITLE
Implement initial init container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [ published ]
+
+jobs:
+
+  build:
+
+    name: Build Image
+
+    runs-on: ubuntu-latest
+
+    env:
+      TAG: ${{ github.event.release.tag_name }}
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set tag for non-release builds
+        if: github.event_name != 'release'
+        run: |
+          echo "TAG=${{ github.sha }}" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        # don't even login to GitHub CR if this is not a release
+        if: github.event_name == 'release'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build / Release
+        uses: docker/build-push-action@v2
+        with:
+          # push and load may not be set together at the moment
+          load: ${{ github.event_name != 'release' }}
+          push: ${{ github.event_name == 'release' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/sonarqube-password-hash:latest
+            ghcr.io/${{ github.repository_owner }}/sonarqube-password-hash:${{ env.TAG }}
+
+      - name: Inspect
+        # as push and load may not be set together at the moment
+        # we can only run this step in non-release builds
+        if: github.event_name != 'release'
+        run: |
+          docker image inspect ghcr.io/${{ github.repository_owner }}/sonarqube-password-hash:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Build image
+
+FROM maven:3.6.0-jdk-11-slim AS build
+
+COPY src /home/app/src
+COPY pom.xml /home/app
+
+RUN mvn -f /home/app/pom.xml clean package --batch-mode
+
+# Execution image
+
+FROM eclipse-temurin:11-jre-jammy
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG CLI_JAR=/usr/local/lib/sonarqube-password-hash.jar
+ARG CLI_BIN=/usr/local/bin/sonarqube-password-hash
+
+RUN apt-get update && \
+    apt-get --no-install-recommends --yes install \
+        postgresql-client \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=build /home/app/target/sonarqube-password-hash-0.0.0-jar-with-dependencies.jar ${CLI_JAR}
+
+RUN echo "#!/bin/env bash\nset -o pipefail\nset -e\njava -jar ${CLI_JAR} \$@" > ${CLI_BIN} && \
+    chmod +x ${CLI_BIN}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# docker-sonarqube-password-hash
+Sonarqube Password Hash
+=======================
+
 Docker image with Sonarqube password hash generator intended to be used for Sonarqube configuration
+
+The code used in this image is based on the Sonarqube local authentication code:
+https://github.com/SonarSource/sonarqube/blob/9.6.0.59041/server/sonar-webserver-auth/src/main/java/org/sonar/server/authentication/CredentialsLocalAuthentication.java

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>de.aservo</groupId>
+    <artifactId>sonarqube-password-hash</artifactId>
+    <version>0.0.0</version>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mindrot</groupId>
+            <artifactId>jbcrypt</artifactId>
+            <version>0.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>de.aservo.sonar.SonarqubePasswordHash</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/de/aservo/sonar/SonarqubePasswordHash.java
+++ b/src/main/java/de/aservo/sonar/SonarqubePasswordHash.java
@@ -1,0 +1,72 @@
+/*
+ * SonarQube
+ * Copyright (C) 2009-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package de.aservo.sonar;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
+
+import static java.lang.String.format;
+
+public class SonarqubePasswordHash {
+
+    // The following values must match the constants from CredentialsLocalAuthentication.java
+    private static final int ITERATIONS = 100_000;
+    private static final char ITERATIONS_HASH_SEPARATOR = '$';
+    private static final int KEY_LEN = 512;
+    private static final String ALGORITHM = String.format("PBKDF2WithHmacSHA%d", KEY_LEN);
+
+    public static void main(final String[] args) {
+        try {
+            assert args.length == 2;
+
+            final String salt = args[0];
+            final String password = args[1];
+
+            System.out.println(hashPassword(salt, password));
+            System.exit(0);
+        } catch (Exception e) {
+            System.out.println("usage: sonarqube-password-hash <SALT> <PASSWORD>");
+            System.exit(1);
+        }
+    }
+
+    private static String hashPassword(final String salt, final String password) {
+        final byte[] saltBytes = Base64.getDecoder().decode(salt);
+        return composeEncryptedPassword(hash(saltBytes, password));
+    }
+
+    private static String composeEncryptedPassword(final String hash) {
+        return format("%d%c%s", ITERATIONS, ITERATIONS_HASH_SEPARATOR, hash);
+    }
+
+    private static String hash(final byte[] salt, final String password) {
+        try {
+            final SecretKeyFactory skf = SecretKeyFactory.getInstance(ALGORITHM);
+            final PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, ITERATIONS, KEY_LEN);
+            final byte[] hash = skf.generateSecret(spec).getEncoded();
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Unfortunately, we noticed that we are not able to generate the password hashes for Sonarqube with the planned nettle CLI provided in the networking image. And as we couldn't find any other CLI providing the required "PBKDF2 with HMAC SHA512" algorithm, and because the implementation of the Sonarqube hash algorithm also includes some Sonarqube-specifics, I've taken the Sonarqube sources and modified them, to build a tiny CLI for it.

This image builds and then later contains the standaline JAR file, a shell script to run the JAR file and the psql CLI, as we need to set the intended password hash (and salt) directly via database updates.

Please check whether everything is compliant in use with GNU LGPL.